### PR TITLE
Don't call drop of provided Space type parameter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@
 #![feature(unsize)]
 #![feature(box_syntax)]
 #![feature(unique)]
+#![feature(untagged_unions)]
 #![feature(used)]
 
 #![cfg_attr(not(feature="std"), no_std)]

--- a/tests/stackbox.rs
+++ b/tests/stackbox.rs
@@ -148,3 +148,18 @@ fn test_zst() {
         unreachable!();
     }
 }
+
+#[test]
+fn test_space_not_allocated() {
+    use std::any::Any;
+
+    struct NeverDrop([usize; 4]);
+
+    impl Drop for NeverDrop {
+        fn drop(&mut self) {
+            unreachable!();
+        }
+    }
+
+    StackBox::<Any, NeverDrop>::new([0usize; 4]).unwrap();
+}


### PR DESCRIPTION
While providing droppable type as Space is dumb, it will cause unsafety when dropping a SmallBox. This commit fixes that.